### PR TITLE
edits to airfoilopt run scripts and docs

### DIFF
--- a/doc/airfoilopt_multipoint.rst
+++ b/doc/airfoilopt_multipoint.rst
@@ -79,6 +79,7 @@ Run it yourself!
 The script can be run in the same way.
 ::
 
+	$ mkdir output
 	$ mpirun -np 4 python airfoil_multiopt.py | tee output.txt
 
 

--- a/doc/airfoilopt_singlepoint.rst
+++ b/doc/airfoilopt_singlepoint.rst
@@ -211,6 +211,7 @@ Run it yourself!
 To run the script, use the ``mpirun`` and place the total number of processors after the ``-np`` argument.
 ::
 
+	$ mkdir output
 	$ mpirun -np 4 python airfoil_opt.py | tee output.txt
 
 The command ``tee`` saves the text outputs of the optimization to the specified text file. You can follow the progress of the optimization using OptView, as explained in pyOptSparse.

--- a/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
+++ b/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
@@ -8,9 +8,8 @@ from baseclasses import *
 from adflow import ADFLOW
 from pygeo import *
 from pyspline import *
-from repostate import *
 from pyoptsparse import Optimization, OPT
-from pywarp import *
+from idwarp import *
 from multipoint import *
 #rst Imports (end)
 # ======================================================================
@@ -178,7 +177,7 @@ if comm.rank == 0:
 #rst warp (beg)
 meshOptions = {'gridFile':'n0012.cgns', 'warpType':'algebraic',}
 
-mesh = MBMesh(options=meshOptions, comm=comm)
+mesh = USMesh(options=meshOptions, comm=comm)
 CFDSolver.setMesh(mesh)
 #rst warp (end)
 # ======================================================================

--- a/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
+++ b/tutorial/airfoilopt/multipoint/airfoil_multiopt.py
@@ -175,7 +175,7 @@ if comm.rank == 0:
 #         Mesh Warping Set-up
 # ======================================================================
 #rst warp (beg)
-meshOptions = {'gridFile':'n0012.cgns', 'warpType':'algebraic',}
+meshOptions = {'gridFile':'n0012.cgns'}
 
 mesh = USMesh(options=meshOptions, comm=comm)
 CFDSolver.setMesh(mesh)

--- a/tutorial/airfoilopt/singlepoint/airfoil_opt.py
+++ b/tutorial/airfoilopt/singlepoint/airfoil_opt.py
@@ -160,7 +160,7 @@ if comm.rank == 0:
 #         Mesh Warping Set-up
 # ======================================================================
 #rst warp (beg)
-meshOptions = {'gridFile':'n0012.cgns', 'warpType':'algebraic',}
+meshOptions = {'gridFile':'n0012.cgns'}
 
 mesh = USMesh(options=meshOptions, comm=comm)
 CFDSolver.setMesh(mesh)

--- a/tutorial/airfoilopt/singlepoint/airfoil_opt.py
+++ b/tutorial/airfoilopt/singlepoint/airfoil_opt.py
@@ -8,9 +8,8 @@ from baseclasses import *
 from adflow import ADFLOW
 from pygeo import *
 from pyspline import *
-from repostate import *
 from pyoptsparse import Optimization, OPT
-from pywarp import *
+from idwarp import *
 from multipoint import *
 #rst Imports (end)
 # ======================================================================
@@ -163,7 +162,7 @@ if comm.rank == 0:
 #rst warp (beg)
 meshOptions = {'gridFile':'n0012.cgns', 'warpType':'algebraic',}
 
-mesh = MBMesh(options=meshOptions, comm=comm)
+mesh = USMesh(options=meshOptions, comm=comm)
 CFDSolver.setMesh(mesh)
 #rst warp (end)
 # ======================================================================

--- a/tutorial/opt/aero/aero_opt.py
+++ b/tutorial/opt/aero/aero_opt.py
@@ -130,7 +130,7 @@ if comm.rank == 0:
 #         Mesh Warping Set-up
 # ======================================================================
 #rst warp (beg)
-meshOptions = {'gridFile':gridFile, 'warpType':'algebraic',}
+meshOptions = {'gridFile':gridFile}
 mesh = USMesh(options=meshOptions, comm=comm)
 CFDSolver.setMesh(mesh)
 #rst warp (end)


### PR DESCRIPTION
The airfoilopt run scripts still used pywarp and repostate. I removed repostate and replaced pywarp with idwarp. I also added 'mkdir output' to the run command in the airfoilopt docs because the run scripts expect the output directory to exist.

I removed the warpType option for idwarp from all optimization run scripts. This is an option in pywarp but not in idwarp.